### PR TITLE
Add cli tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
           name: coverage-report
           path: lcov.info
       - name: Install lcov
-        run: sudo apt-get update && sudo apt-get install -y lcov
+        run: sudo apt-get install -y lcov
       - name: Generate HTML report
         run: |
           mkdir -p coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ shellexpand = "3.1.1"
 which = "8.0.0"
 comfy-table = "7.2.1"
 ctrlc = "3.5.0"
+
+[dev-dependencies]
+assert_cli = "0.6.3"

--- a/src/cfg/settings.rs
+++ b/src/cfg/settings.rs
@@ -55,12 +55,10 @@ impl Settings {
                 Config::default()
             });
 
-        // Use the config to load the settings
         let new_settings: Settings = settings
             .try_deserialize()
             .unwrap_or_else(|_| Settings::default());
 
-        // Validate the venv Path
         new_settings.validate_venv_path();
 
         let mut settings_lock = SETTINGS.lock().expect("Failed to lock settings");

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 pub async fn activate(name_pos: Option<String>, name: Option<String>) {
-    //let venv = util::find_venv(name_pos, name, "activate").await;
     let venv = venvmanager::VENVMANAGER
         .find_venv(name_pos, name, "activate")
         .await;

--- a/src/core/venv.rs
+++ b/src/core/venv.rs
@@ -39,7 +39,6 @@ impl Venv {
     pub async fn create(&self) -> Result<(), String> {
         let settings = settings::Settings::get_settings();
         let pwd = std::env::current_dir().unwrap();
-        // set pwd to settings venvs_path
         let path = shellexpand::tilde(&settings.venvs_path).to_string();
         std::env::set_current_dir(&path).unwrap();
         let args = &[

--- a/src/core/venvmanager.rs
+++ b/src/core/venvmanager.rs
@@ -119,7 +119,6 @@ mod tests {
     #[tokio::test]
     async fn test_list_venvs() {
         let venvs = VENVMANAGER.list().await;
-        // Assuming there are no virtual environments for the test
         assert!(venvs.is_empty());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,12 +56,6 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-
-    #[test]
     fn test_cli_output_help() {
         assert_cli::Assert::main_binary()
             .with_args(&["--help"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,3 +52,90 @@ async fn main() {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+
+    #[test]
+    fn test_cli_output_help() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["--help"])
+            .succeeds()
+            .and()
+            .stdout()
+            .contains("A simple CLI to manage Python virtual enviroonments using Astral UV")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_cli_output_version() {
+        let version = env!("CARGO_PKG_VERSION");
+        assert_cli::Assert::main_binary()
+            .with_args(&["--version"])
+            .succeeds()
+            .and()
+            .stdout()
+            .contains(format!("PyPilot {}", version).as_str())
+            .unwrap();
+    }
+
+    #[test]
+    fn test_cli_output_check() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["check"])
+            .succeeds()
+            .and()
+            .stdout()
+            .contains("Checking if Astral UV is installed and configured...")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_cli_output_activate() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["activate"])
+            .succeeds()
+            .and()
+            .stdout()
+            .contains("No virtual environments found")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_cli_output_delete() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["delete"])
+            .succeeds()
+            .and()
+            .stdout()
+            .contains("No virtual environments found")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_cli_output_delete_name() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["delete", "myvenv"])
+            .succeeds()
+            .and()
+            .stdout()
+            .contains("Virtual environment does not exist")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_cli_output_activate_name() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["activate", "myvenv"])
+            .succeeds()
+            .and()
+            .stdout()
+            .contains("Virtual environment does not exist")
+            .unwrap();
+    }
+}


### PR DESCRIPTION
This pull request introduces automated CLI integration tests for the project, ensuring that key commands produce the expected output. It also adds the necessary testing dependency and makes a minor optimization to the CI workflow.

**Testing improvements:**

* Added `assert_cli` as a development dependency in `Cargo.toml` to enable CLI integration testing.
* Introduced a new test module in `src/main.rs` with tests that verify the output of the CLI for commands such as `--help`, `--version`, `check`, `activate`, and `delete`, including cases for non-existent virtual environments.

**CI/CD improvements:**

* Removed the redundant `apt-get update` step from the GitHub Actions workflow, slightly optimizing the installation of `lcov`.